### PR TITLE
Wit api 20160526

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ $intent = json_decode((string) $response->getBody(), true);
 
 ```
 
-You can used the `Api` class which provided some shortcut to call the wit api:
+You can used the `Message` api class to extract meaning of a sentence:
 
 ```php
 
 require_once __DIR__.'/vendor/autoload.php';
 
 use Tgallice\Wit\Client;
-use Tgallice\Wit\Api;
+use Tgallice\Wit\MessageApi;
 
 $client = new Client('app_token');
-$api = new Api($client);
+$api = new MessageApi($client);
 
-$intent = $api->getIntentByText('Hello I live in London');
+$meaning = $api->extractMeaning('Hello I live in London');
 
 ```
 
@@ -96,12 +96,12 @@ And using it in the `Conversation` class.
 require_once __DIR__.'/vendor/autoload.php';
 
 use Tgallice\Wit\Client;
-use Tgallice\Wit\Api;
-use Tgallice\Wit\Api\Conversation;
+use Tgallice\Wit\ConverseApi;
+use Tgallice\Wit\Conversation;
 use Custom\MyActionMapping;
 
 $client = new Client('app_token');
-$api = new Api($client);
+$api = new ConverseApi($client);
 $actionMapping = new MyActionMapping();
 $conversation = new Conversation($api, $actionMapping);
 
@@ -112,12 +112,6 @@ $context = $conversation->converse('session_id', 'Hello I live in London');
 `Conversation::converse()` return the last available `Context`.
 
 Some examples are describe in the [tgallice/php-wit-example][2] repository.
-
-## TODO
-
-- [ ] Create dedicated Api class for Intent
-- [ ] Create dedicated Api class for Entity
-- [ ] Response Model
 
 [1]: https://wit.ai
 [2]: https://github.com/tgallice/wit-php-example

--- a/spec/ApiSpec.php
+++ b/spec/ApiSpec.php
@@ -34,33 +34,6 @@ class ApiSpec extends ObjectBehavior
         $this->getConverseNextStep('session_id', 'my message', $context)->shouldReturn(['field' => 'value']);
     }
 
-    function it_should_get_intent_by_text($client, $response)
-    {
-        $context = new Context();
-        $query = [
-            'q' => 'my text',
-            'context' => json_encode($context),
-            'foo' => 'bar',
-        ];
-
-        $client->get('/message', $query)->willReturn($response);
-
-        $this->getIntentByText('my text', $context, ['foo' => 'bar'])->shouldReturn(['field' => 'value']);
-    }
-
-    function it_should_get_intent_by_text_without_override_query_message($client, $response)
-    {
-        $context = new Context();
-        $query = [
-            'q' => 'my text',
-            'context' => json_encode($context),
-        ];
-
-        $client->get('/message', $query)->willReturn($response);
-
-        $this->getIntentByText('my text', $context, ['q' => 'other message'])->shouldReturn(['field' => 'value']);
-    }
-
     function it_should_get_intent_by_speech_when_its_a_resource_given($client, $response)
     {
         $resource = fopen('php://temp', 'r+');

--- a/spec/ApiSpec.php
+++ b/spec/ApiSpec.php
@@ -34,42 +34,6 @@ class ApiSpec extends ObjectBehavior
         $this->getConverseNextStep('session_id', 'my message', $context)->shouldReturn(['field' => 'value']);
     }
 
-    function it_should_get_intent_by_speech_when_its_a_resource_given($client, $response)
-    {
-        $resource = fopen('php://temp', 'r+');
-        $context = new Context();
-        $query = ['context' => json_encode($context), 'foo' => 'bar'];
-
-        $client->send('POST', '/speech', $resource, $query)->willReturn($response);
-
-        $this->getIntentBySpeech($resource, $context, ['foo' => 'bar'])->shouldReturn(['field' => 'value']);
-
-        fclose($resource);
-    }
-
-    function it_should_get_intent_by_speech_when_its_filename_given($client, $response)
-    {
-        $context = new Context();
-        $query = ['context' => json_encode($context), 'foo' => 'bar'];
-        $file = tempnam(sys_get_temp_dir(), 'test');
-
-        $client->send('POST', '/speech', Argument::that(function ($argument) {
-            $isResource = is_resource($argument);
-
-            fclose($argument);
-
-            return $isResource;
-        }), $query)->willReturn($response);
-
-        $this->getIntentBySpeech($file, $context, ['foo' => 'bar'])->shouldReturn(['field' => 'value']);
-    }
-
-    function it_should_throw_exception_when_get_intent_by_speech_with_an_invalid_file_argument()
-    {
-        $this->shouldThrow(new \InvalidArgumentException('$file argument must be a readable file path or a valid resource'))
-            ->duringGetIntentBySpeech('wrong_file.txt');
-    }
-
     function it_should_get_message_by_id($client, $response)
     {
         $client->get('/messages/id')->willReturn($response);

--- a/spec/ApiSpec.php
+++ b/spec/ApiSpec.php
@@ -21,19 +21,6 @@ class ApiSpec extends ObjectBehavior
         $this->shouldHaveType('Tgallice\Wit\Api');
     }
 
-    function it_should_get_converse_next_step_with_the_api($client, $response)
-    {
-        $context = new Context();
-        $query = [
-            'session_id' => 'session_id',
-            'q' => 'my message',
-        ];
-
-        $client->send('POST', '/converse', $context, $query)->willReturn($response);
-
-        $this->getConverseNextStep('session_id', 'my message', $context)->shouldReturn(['field' => 'value']);
-    }
-
     function it_should_get_message_by_id($client, $response)
     {
         $client->get('/messages/id')->willReturn($response);

--- a/spec/ConverseApiSpec.php
+++ b/spec/ConverseApiSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\Tgallice\Wit;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Tgallice\Wit\Client;
+use Tgallice\Wit\Model\Context;
+use Tgallice\Wit\ResponseHandler;
+
+class ConverseApiSpec extends ObjectBehavior
+{
+    function let(Client $client)
+    {
+        $this->beConstructedWith($client);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Tgallice\Wit\ConverseApi');
+    }
+
+    function it_should_converse($client, ResponseInterface $response)
+    {
+        $body = '
+            {
+                "type": "merge",
+                "entities": {
+                    "location": [
+                        {
+                            "body": "Brussels",
+                            "value": {
+                                "type": "value",
+                                "value": "Brussels",
+                                "suggested": true
+                            },
+                            "start": 11,
+                            "end": 19,
+                            "entity": "location"
+                        }
+                    ]
+                },
+                "confidence": 1
+            }
+        ';
+
+        $context = new Context();
+        $query = [
+            'session_id' => 'session_id',
+            'q' => 'my message',
+        ];
+
+        $response->getBody()->willReturn($body);
+        $client->send('POST', '/converse', $context, $query)->willReturn($response);
+
+        $this->converse('session_id', 'my message', $context)->shouldReturn(json_decode($body, true));
+    }
+}

--- a/spec/EntityApiSpec.php
+++ b/spec/EntityApiSpec.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace spec\Tgallice\Wit;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Tgallice\Wit\Api;
+use Tgallice\Wit\Client;
+use Tgallice\Wit\Model\EntityValue;
+
+class EntityApiSpec extends ObjectBehavior
+{
+    function let(Client $client)
+    {
+        $this->beConstructedWith($client);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Tgallice\Wit\EntityApi');
+    }
+
+    function it_should_get_entities($client, ResponseInterface $response)
+    {
+        $body = '
+            [
+                "wit$amount_of_money",
+                "wit$contact",
+                "wit$datetime",
+                "wit$on_off",
+                "wit$phrase_to_translate",
+                "wit$temperature"
+            ]
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->get('/entities')->willReturn($response);
+
+        $this->get()->shouldReturn($expected);
+    }
+
+    function it_should_create_entities($client, ResponseInterface $response, EntityValue $entityValue)
+    {
+        $body = '
+            {
+                "name" : "favorite_city",
+                "lang" : "en",
+                "lookups" : [ "keywords" ],
+                "builtin" : false,
+                "doc" : "A city that I like",
+                "id" : "5418abc7-cc68-4073-ae9e-3a5c3c81d965"
+            }
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->post('/entities', [
+            'doc' => 'description',
+            'id' => 'favorite_city',
+            'values' => [$entityValue],
+            'lookups' => 'lookups',
+        ])->willReturn($response);
+
+        $this->create('favorite_city', [$entityValue], 'description', 'lookups')->shouldReturn($expected);
+    }
+
+    function it_should_get_an_entity($client, ResponseInterface $response)
+    {
+        $body = '
+            {
+                "builtin" : false,
+                "doc" : "User-defined entity",
+                "id" : "571979db-f6ac-4820-bc28-a1e0787b98fc",
+                "lang" : "en",
+                "lookups" : [ "keywords", "free-text" ],
+                "name" : "first_name",
+                "values" : [
+                    {"value" : "Willy",
+                    "expressions" : [ "Willy" ]
+                    }, {
+                    "value" : "Laurent",
+                    "expressions" : [ "Laurent" ]
+                    }, {
+                    "value" : "Julien",
+                    "expressions" : [ "Julien" ]
+                    }, {
+                    "value" : "Alex",
+                    "expressions" : [ "Alex" ]
+                    }
+                ]
+            }
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->get('/entities/first_name')->willReturn($response);
+
+        $this->get('first_name')->shouldReturn($expected);
+    }
+
+    function it_should_update_an_entity($client, ResponseInterface $response, EntityValue $entityValue)
+    {
+        $body = '
+            {
+                "builtin" : false,
+                "doc" : "These are cities worth going to",
+                "name" : "favorite_city",
+                "id" : "5418abc7-cc68-4073-ae9e-3a5c3c81d965",
+                "lang" : "en",
+                "lookups" : [ "keywords" ]
+            }
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->put('/entities/favorite_city', [
+            'values' => [$entityValue],
+            'doc' => 'description',
+            'id' => 'id',
+        ])->willReturn($response);
+
+        $this->update('favorite_city', [$entityValue], 'description', 'id')->shouldReturn($expected);
+    }
+
+    function it_should_delete_an_entity($client, ResponseInterface $response)
+    {
+        $body = '
+            {
+                "deleted" : "5418abc7-cc68-4073-ae9e-3a5c3c81d965"
+            }
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->delete('/entities/favorite_city')->willReturn($response);
+
+        $this->delete('favorite_city')->shouldReturn($expected);
+    }
+
+    function it_should_add_a_value_to_an_entity($client, ResponseInterface $response, EntityValue $entityValue)
+    {
+        $body = '
+            {
+                "builtin" : false,
+                "doc" : "These are cities worth going to",
+                "exotic" : false,
+                "id" : "57475251-ba5a-412b-85ec-3ab6f778d6fa",
+                "lang" : "en",
+                "lookups" : [ "keywords" ],
+                "name" : "favorite_city"
+            }
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->send('POST', '/entities/favorite_city/values', $entityValue)->willReturn($response);
+
+        $this->addValue('favorite_city', $entityValue)->shouldReturn($expected);
+    }
+
+    function it_should_delete_a_value_to_an_entity($client, ResponseInterface $response)
+    {
+        $body = '';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->delete('/entities/favorite_city/values/Paris')->willReturn($response);
+
+        $this->deleteValue('favorite_city', 'Paris')->shouldReturn($expected);
+    }
+
+    function it_should_add_an_expression_to_an_entity_value($client, ResponseInterface $response)
+    {
+        $body = '
+            {
+                "builtin" : false,
+                "doc" : "These are cities worth going to",
+                "exotic" : false,
+                "id" : "57475251-ba5a-412b-85ec-3ab6f778d6fa",
+                "lang" : "en",
+                "lookups" : [ "keywords" ],
+                "name" : "favorite_city"
+            }
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->post('/entities/favorite_city/values/Paris/expressions', [
+            'expression' => 'Camembert city',
+        ])->willReturn($response);
+
+        $this->addExpression('favorite_city', 'Paris', 'Camembert city')->shouldReturn($expected);
+    }
+
+    function it_should_delete_an_expression_to_an_entity_value($client, ResponseInterface $response)
+    {
+        $body = '
+            {
+                "deleted" : "Camembert city"
+            }
+        ';
+
+        $expected = json_decode($body, true);
+        $response->getBody()->willReturn($body);
+        $client->delete('/entities/favorite_city/values/Paris/expressions/Camembert city')->willReturn($response);
+
+        $this->deleteExpression('favorite_city', 'Paris', 'Camembert city')->shouldReturn($expected);
+    }
+}

--- a/spec/MessageApiSpec.php
+++ b/spec/MessageApiSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace spec\Tgallice\Wit;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Tgallice\Wit\Client;
+use Tgallice\Wit\Model\Context;
+
+class MessageApiSpec extends ObjectBehavior
+{
+    function let(Client $client, ResponseInterface $response)
+    {
+        $response->getBody()->willReturn('{"field": "value"}');
+        $this->beConstructedWith($client);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Tgallice\Wit\MessageApi');
+    }
+
+    function it_should_extract_meaning_of_sentence($client, $response)
+    {
+        $context = new Context();
+        $query = [
+            'q' => 'my text',
+            'context' => json_encode($context),
+            'foo' => 'bar',
+        ];
+
+        $client->get('/message', $query)->willReturn($response);
+
+        $this->extractMeaning('my text', $context, ['foo' => 'bar'])->shouldReturn(['field' => 'value']);
+    }
+
+    function it_should_extract_meaning_of_sentence_without_override_query_message($client, $response)
+    {
+        $context = new Context();
+        $query = [
+            'q' => 'my text',
+            'context' => json_encode($context),
+        ];
+
+        $client->get('/message', $query)->willReturn($response);
+
+        $this->extractMeaning('my text', $context, ['q' => 'other message'])->shouldReturn(['field' => 'value']);
+    }
+}

--- a/spec/Model/EntitySpec.php
+++ b/spec/Model/EntitySpec.php
@@ -4,6 +4,8 @@ namespace spec\Tgallice\Wit\Model;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Tgallice\Wit\Model\Entity;
+use Tgallice\Wit\Model\EntityValue;
 
 class EntitySpec extends ObjectBehavior
 {
@@ -27,9 +29,15 @@ class EntitySpec extends ObjectBehavior
         $this->getDescription()->shouldReturn('description');
     }
 
-    function it_has_values()
+    function it_has_values(EntityValue $entityValue)
     {
-        $this->getValues()->shouldReturn([]);
+        $this->beConstructedWith('id', [$entityValue]);
+        $this->getValues()->shouldEqual([$entityValue]);
+    }
+
+    function it_has_a_lookups()
+    {
+        $this->getLookups()->shouldReturn([Entity::LOOKUP_KEYWORDS]);
     }
 
     function it_must_be_json_serializable()

--- a/spec/Model/EntityValueSpec.php
+++ b/spec/Model/EntityValueSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace spec\Tgallice\Wit\Model;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class EntityValueSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('value', ['expressions'], 'metadata');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Tgallice\Wit\Model\EntityValue');
+    }
+
+    function it_has_a_value()
+    {
+        $this->getValue()->shouldReturn('value');
+    }
+
+    function it_has_expressions()
+    {
+        $this->getExpressions()->shouldReturn(['expressions']);
+    }
+
+    function it_has_metadata()
+    {
+        $this->getMetadata()->shouldReturn('metadata');
+    }
+
+    function it_must_be_json_serializable()
+    {
+        $this->shouldHaveType(\JsonSerializable::class);
+        $serialized = json_encode($this->getWrappedObject());
+        $this->jsonSerialize()->shouldReturn(json_decode($serialized, true));
+    }
+}

--- a/spec/SpeechApiSpec.php
+++ b/spec/SpeechApiSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\Tgallice\Wit;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Tgallice\Wit\Client;
+use Tgallice\Wit\Model\Context;
+
+class SpeechApiSpec extends ObjectBehavior
+{
+    function let(Client $client, ResponseInterface $response)
+    {
+        $response->getBody()->willReturn('{"field" : "value"}');
+        $this->beConstructedWith($client);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Tgallice\Wit\SpeechApi');
+    }
+
+    function it_should_extract_meaning_of_speech($client, ResponseInterface $response)
+    {
+        $resource = fopen('php://temp', 'r+');
+        $context = new Context();
+        $query = ['context' => json_encode($context), 'foo' => 'bar'];
+
+        $client->send('POST', '/speech', $resource, $query)->willReturn($response);
+
+        $this->extractMeaning($resource, $context, ['foo' => 'bar'])->shouldReturn(['field' => 'value']);
+
+        fclose($resource);
+    }
+
+    function it_should_extract_meaning_of_speech_when_its_filename_given($client, $response)
+    {
+        $context = new Context();
+        $query = ['context' => json_encode($context), 'foo' => 'bar'];
+        $file = tempnam(sys_get_temp_dir(), 'test');
+
+        $client->send('POST', '/speech', Argument::that(function ($argument) {
+            $isResource = is_resource($argument);
+
+            fclose($argument);
+
+            return $isResource;
+        }), $query)->willReturn($response);
+
+        $this->extractMeaning($file, $context, ['foo' => 'bar'])->shouldReturn(['field' => 'value']);
+    }
+
+    function it_should_throw_exception_when_extract_meaning_of_speech_with_an_invalid_file_argument()
+    {
+        $this->shouldThrow(new \InvalidArgumentException('$file argument must be a readable file path or a valid resource'))
+            ->duringExtractMeaning('wrong_file.txt');
+    }
+}

--- a/src/Api.php
+++ b/src/Api.php
@@ -3,6 +3,7 @@
 namespace Tgallice\Wit;
 
 use Psr\Http\Message\ResponseInterface;
+use Tgallice\Wit\Api\Speech;
 use Tgallice\Wit\Model\Context;
 
 class Api
@@ -13,11 +14,17 @@ class Api
     private $client;
 
     /**
+     * @var MessageApi
+     */
+    private $messageApi;
+
+    /*
      * @param Client $client
      */
     public function __construct(Client $client)
     {
         $this->client = $client;
+        $this->messageApi = new MessageApi($client);
     }
 
     /**
@@ -40,6 +47,9 @@ class Api
     }
 
     /**
+     * @deprecated This method is deprecated as of 0.1 and will be removed in 1.0.
+     *             You should use the MessageApi::extractMeaning() instead
+     *
      * @param string $text
      * @param Context|null $context
      * @param array $extraParams
@@ -48,17 +58,7 @@ class Api
      */
     public function getIntentByText($text, Context $context = null, array $extraParams = [])
     {
-        $query = array_merge($extraParams, [
-            'q' => $text,
-        ]);
-
-        if (null !== $context) {
-            $query['context'] = json_encode($context);
-        }
-
-        $response = $this->client->get('/message', $query);
-
-        return $this->decodeResponse($response);
+        return $this->messageApi->extractMeaning($text, $context, $extraParams);
     }
 
     /**

--- a/src/Api.php
+++ b/src/Api.php
@@ -5,6 +5,9 @@ namespace Tgallice\Wit;
 use Psr\Http\Message\ResponseInterface;
 use Tgallice\Wit\Model\Context;
 
+/**
+ * @deprecated This class is deprecated as of 0.1 and will be removed in 1.0.
+ */
 class Api
 {
     /**
@@ -23,6 +26,11 @@ class Api
     private $speechApi;
 
     /**
+     * @var ConverseApi
+     */
+    private $converseApi;
+
+    /**
      * @param Client $client
      */
     public function __construct(Client $client)
@@ -30,9 +38,13 @@ class Api
         $this->client = $client;
         $this->messageApi = new MessageApi($client);
         $this->speechApi = new SpeechApi($client);
+        $this->converseApi = new ConverseApi($client);
     }
 
     /**
+     * @deprecated This method is deprecated as of 0.1 and will be removed in 1.0.
+     *             You should use the ConverseApi::converse() instead
+     *
      * @param string $sessionId
      * @param string $text
      * @param Context|null $context
@@ -41,14 +53,7 @@ class Api
      */
     public function getConverseNextStep($sessionId, $text, Context $context = null)
     {
-        $query = [
-            'session_id' => $sessionId,
-            'q' => $text,
-        ];
-
-        $response = $this->client->send('POST', '/converse', $context, $query);
-
-        return $this->decodeResponse($response);
+        return $this->converseApi->converse($sessionId, $text, $context);
     }
 
     /**

--- a/src/Api.php
+++ b/src/Api.php
@@ -3,7 +3,6 @@
 namespace Tgallice\Wit;
 
 use Psr\Http\Message\ResponseInterface;
-use Tgallice\Wit\Api\Speech;
 use Tgallice\Wit\Model\Context;
 
 class Api
@@ -18,13 +17,19 @@ class Api
      */
     private $messageApi;
 
-    /*
+    /**
+     * @var SpeechApi
+     */
+    private $speechApi;
+
+    /**
      * @param Client $client
      */
     public function __construct(Client $client)
     {
         $this->client = $client;
         $this->messageApi = new MessageApi($client);
+        $this->speechApi = new SpeechApi($client);
     }
 
     /**
@@ -62,6 +67,9 @@ class Api
     }
 
     /**
+     * @deprecated This method is deprecated as of 0.1 and will be removed in 1.0.
+     *             You should use the SpeechApi::extractMeaning() instead
+     *
      * @param string|resource $file
      * @param array|null $context
      * @param array $queryParams
@@ -70,21 +78,12 @@ class Api
      */
     public function getIntentBySpeech($file, Context $context = null, array $queryParams = [])
     {
-        if (!$file || (!is_resource($file) && !is_readable($file))) {
-            throw new \InvalidArgumentException('$file argument must be a readable file path or a valid resource');
-        }
-
-        if (null !== $context) {
-            $queryParams['context'] = json_encode($context);
-        }
-
-        $file = is_resource($file) ? $file : fopen($file, 'r');
-        $response = $this->client->send('POST', '/speech', $file, $queryParams);
-
-        return $this->decodeResponse($response);
+        return $this->speechApi->extractMeaning($file, $context, $queryParams);
     }
 
     /**
+     * @deprecated This method is deprecated as of 0.1 and will be removed in 1.0.
+     *
      * @param string $messageId
      *
      * @return array|null

--- a/src/Api/Conversation.php
+++ b/src/Api/Conversation.php
@@ -4,36 +4,27 @@ namespace Tgallice\Wit\Api;
 
 use Tgallice\Wit\ActionMapping;
 use Tgallice\Wit\Api;
-use Tgallice\Wit\Exception\BadResponseException;
-use Tgallice\Wit\Exception\ConversationException;
-use Tgallice\Wit\Exception\InvalidStepException;
-use Tgallice\Wit\Exception\MaxIterationException;
+use Tgallice\Wit\Conversation as ConversationDelegate;
+use Tgallice\Wit\ConverseApi;
 use Tgallice\Wit\Model\Context;
 use Tgallice\Wit\Model\Step;
-use Tgallice\Wit\Model\Step\Action;
-use Tgallice\Wit\Model\Step\Merge;
-use Tgallice\Wit\Model\Step\Message;
-use Tgallice\Wit\Model\Step\Stop;
-use Tgallice\Wit\StepFactory;
 
+/**
+ * @deprecated This class is deprecated as of 0.1 and will be removed in 1.0.
+ */
 class Conversation
 {
     const MAX_STEPS_ITERATION = 5;
 
     /**
-     * @var Api
+     * @var ConversationDelegate
      */
-    private $api;
-
-    /**
-     * @var ActionMapping
-     */
-    private $actionMapping;
+    private $conversation;
 
     public function __construct(Api $api, ActionMapping $actionMapping)
     {
-        $this->api = $api;
-        $this->actionMapping = $actionMapping;
+        $converseApi = new ConverseApi($api->getClient());
+        $this->conversation = new ConversationDelegate($converseApi, $actionMapping);
     }
 
     /**
@@ -46,86 +37,6 @@ class Conversation
      */
     public function converse($sessionId, $message = null, Context $context = null, $stepIteration = self::MAX_STEPS_ITERATION)
     {
-        $context = (null !== $context) ? $context : new Context();
-
-        if ($stepIteration <= 0) {
-            $error = new MaxIterationException("Max iteration exceeded");
-            $this->actionMapping->error($sessionId, $context, $error);
-
-            return $context;
-        }
-
-        try {
-            $step = $this->getNextStep($sessionId, $message, $context);
-        } catch (\Exception $e) {
-            // Trigger the error action
-            $stepData = $e instanceof ConversationException ? $e->getStepData() : [];
-            $this->actionMapping->error($sessionId, $context, $e, $stepData);
-
-            return new Context();
-        }
-
-        return $this->performStep($sessionId, $step, $context, $stepIteration);
-    }
-
-    /**
-     * @param string $sessionId
-     * @param string|null $message
-     * @param Context $context
-     *
-     * @return Step Step object
-     *
-     * @throws BadResponseException
-     * @throws ConversationException
-     */
-    private function getNextStep($sessionId, $message, Context $context)
-    {
-        $stepData = $this->api->getConverseNextStep($sessionId, $message, $context);
-
-        if (null === $stepData) {
-            $stepData = [];
-        }
-
-        if (isset($stepData['error'])) {
-            throw new ConversationException($stepData['error'], $sessionId, $context, $stepData);
-        }
-
-        try {
-            $step = StepFactory::create($stepData);
-        } catch (InvalidStepException $e) {
-            throw new ConversationException($e->getMessage(), $sessionId, $context, $e->getStepData());
-        }
-
-        return $step;
-    }
-
-    /**
-     * @param $sessionId
-     * @param Step $step
-     * @param Context $context
-     * @param int $currentIteration
-     *
-     * @return Context
-     */
-    private function performStep($sessionId, Step $step, Context $context, $currentIteration)
-    {
-        switch (true) {
-            case $step instanceof Merge:
-                $newContext = $this->actionMapping->merge($sessionId, $context, $step->getEntities());
-                $context = $this->converse($sessionId, null, $newContext, --$currentIteration);
-                break;
-            case $step instanceof Message:
-                $this->actionMapping->say($sessionId, $step->getMessage(), $context);
-                break;
-            case $step instanceof Action:
-                $newContext = $this->actionMapping->action($sessionId, $step->getAction(), $context);
-                $context = $this->converse($sessionId, null, $newContext, --$currentIteration);
-                break;
-            case $step instanceof Stop:
-                $this->actionMapping->stop($sessionId, $context);
-                break;
-        }
-
-        return $context;
+        return $this->conversation->converse($sessionId, $message, $context, $stepIteration);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client
     /*
      * API Version
      */
-    const DEFAULT_API_VERSION = '20160330';
+    const DEFAULT_API_VERSION = '20160526';
 
     /**
      * Request default timeout

--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tgallice\Wit;
+
+use Tgallice\Wit\Exception\BadResponseException;
+use Tgallice\Wit\Exception\ConversationException;
+use Tgallice\Wit\Exception\InvalidStepException;
+use Tgallice\Wit\Exception\MaxIterationException;
+use Tgallice\Wit\Model\Context;
+use Tgallice\Wit\Model\Step;
+use Tgallice\Wit\Model\Step\Action;
+use Tgallice\Wit\Model\Step\Merge;
+use Tgallice\Wit\Model\Step\Message;
+use Tgallice\Wit\Model\Step\Stop;
+
+class Conversation
+{
+    const MAX_STEPS_ITERATION = 5;
+
+    /**
+     * @var ConverseApi
+     */
+    private $converseApi;
+
+    /**
+     * @var ActionMapping
+     */
+    private $actionMapping;
+
+    public function __construct(ConverseApi $converseApi, ActionMapping $actionMapping)
+    {
+        $this->converseApi = $converseApi;
+        $this->actionMapping = $actionMapping;
+    }
+
+    /**
+     * @param string $sessionId
+     * @param string|null $message
+     * @param Context|null $context
+     * @param int $stepIteration
+     *
+     * @return Context The new Context
+     */
+    public function converse($sessionId, $message = null, Context $context = null, $stepIteration = self::MAX_STEPS_ITERATION)
+    {
+        $context = (null !== $context) ? $context : new Context();
+
+        if ($stepIteration <= 0) {
+            $error = new MaxIterationException("Max iteration exceeded");
+            $this->actionMapping->error($sessionId, $context, $error);
+
+            return $context;
+        }
+
+        try {
+            $step = $this->getNextStep($sessionId, $message, $context);
+        } catch (\Exception $e) {
+            // Trigger the error action
+            $stepData = $e instanceof ConversationException ? $e->getStepData() : [];
+            $this->actionMapping->error($sessionId, $context, $e, $stepData);
+
+            return new Context();
+        }
+
+        return $this->performStep($sessionId, $step, $context, $stepIteration);
+    }
+
+    /**
+     * @param string $sessionId
+     * @param string|null $message
+     * @param Context $context
+     *
+     * @return Step Step object
+     *
+     * @throws BadResponseException
+     * @throws ConversationException
+     */
+    private function getNextStep($sessionId, $message, Context $context)
+    {
+        $stepData = $this->converseApi->converse($sessionId, $message, $context);
+
+        if (null === $stepData) {
+            $stepData = [];
+        }
+
+        if (isset($stepData['error'])) {
+            throw new ConversationException($stepData['error'], $sessionId, $context, $stepData);
+        }
+
+        try {
+            $step = StepFactory::create($stepData);
+        } catch (InvalidStepException $e) {
+            throw new ConversationException($e->getMessage(), $sessionId, $context, $e->getStepData());
+        }
+
+        return $step;
+    }
+
+    /**
+     * @param $sessionId
+     * @param Step $step
+     * @param Context $context
+     * @param int $currentIteration
+     *
+     * @return Context
+     */
+    private function performStep($sessionId, Step $step, Context $context, $currentIteration)
+    {
+        switch (true) {
+            case $step instanceof Merge:
+                $newContext = $this->actionMapping->merge($sessionId, $context, $step->getEntities());
+                $context = $this->converse($sessionId, null, $newContext, --$currentIteration);
+                break;
+            case $step instanceof Message:
+                $this->actionMapping->say($sessionId, $step->getMessage(), $context);
+                break;
+            case $step instanceof Action:
+                $newContext = $this->actionMapping->action($sessionId, $step->getAction(), $context);
+                $context = $this->converse($sessionId, null, $newContext, --$currentIteration);
+                break;
+            case $step instanceof Stop:
+                $this->actionMapping->stop($sessionId, $context);
+                break;
+        }
+
+        return $context;
+    }
+}

--- a/src/ConverseApi.php
+++ b/src/ConverseApi.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tgallice\Wit;
+
+use Tgallice\Wit\Model\Context;
+
+class ConverseApi
+{
+    use ResponseHandler;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function converse($sessionId, $text, Context $context = null)
+    {
+        $query = [
+            'session_id' => $sessionId,
+            'q' => $text,
+        ];
+
+        $response = $this->client->send('POST', '/converse', $context, $query);
+
+        return $this->decodeResponse($response);
+    }
+}

--- a/src/EntityApi.php
+++ b/src/EntityApi.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tgallice\Wit;
+
+use Tgallice\Wit\Model\EntityValue;
+use Tgallice\Wit\Model\Entity;
+
+class EntityApi
+{
+    use ResponseHandler;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param null|string $entityId
+     *
+     * @return mixed
+     */
+    public function get($entityId = null)
+    {
+        if (null !== $entityId) {
+            $entityId = '/'.$entityId;
+        }
+
+
+        $response = $this->client->get(sprintf('/entities%s', $entityId));
+
+        return $this->decodeResponse($response);
+    }
+
+    /**
+     * @param string $entityId
+     * @param EntityValue[] $entityValues
+     * @param null|string $description
+     * @param null|string $newId
+     *
+     * @return mixed
+     */
+    public function update($entityId, array $entityValues = [], $description = null, $newId = null)
+    {
+        $data = [];
+
+        if (!empty($entityValues)) {
+            $data['values'] = $entityValues;
+        }
+
+        if (!empty($description)) {
+            $data['doc'] = $description;
+        }
+
+        if (!empty($newId)) {
+            $data['id'] = $newId;
+        }
+
+        $response = $this->client->put(sprintf('/entities/%s', $entityId), $data);
+
+        return $this->decodeResponse($response);
+    }
+
+    /**
+     * @param string $entityId
+     *
+     * @return mixed
+     */
+    public function delete($entityId)
+    {
+        $response = $this->client->delete(sprintf('/entities/%s', $entityId));
+
+        return $this->decodeResponse($response);
+    }
+
+    /**
+     * @param string $entityId
+     * @param string $entityValue
+     * @return mixed
+     */
+    public function deleteValue($entityId, $entityValue)
+    {
+        $response = $this->client->delete(sprintf('/entities/%s/values/%s', $entityId, $entityValue));
+
+        return $this->decodeResponse($response);
+    }
+
+    /**
+     * @param string $entityId
+     * @param EntityValue $entityValue
+     *
+     * @return mixed
+     */
+    public function addValue($entityId, EntityValue $entityValue)
+    {
+        $response = $this->client->send('POST', sprintf('/entities/%s/values', $entityId), $entityValue);
+
+        return $this->decodeResponse($response);
+    }
+
+    /**
+     * @param string $entityId
+     * @param string $entityValue
+     * @param string $expression
+     *
+     * @return mixed
+     */
+    public function addExpression($entityId, $entityValue, $expression)
+    {
+        $response = $this->client->post(sprintf('/entities/%s/values/%s/expressions', $entityId, $entityValue), [
+            'expression' => $expression,
+        ]);
+
+        return $this->decodeResponse($response);
+    }
+
+    /**
+     * @param string $entityId
+     * @param string $entityValue
+     * @param string $expression
+     *
+     * @return mixed
+     */
+    public function deleteExpression($entityId, $entityValue, $expression)
+    {
+        $response = $this->client->delete(sprintf('/entities/%s/values/%s/expressions/%s', $entityId, $entityValue, $expression));
+
+        return $this->decodeResponse($response);
+    }
+
+    /**
+     * @param string $entityId
+     * @param EntityValue[] $entityValues
+     * @param null|string $description
+     * @param array $lookups
+     *
+     * @return mixed
+     */
+    public function create($entityId, array $entityValues = [], $description = null, $lookups = [Entity::LOOKUP_KEYWORDS])
+    {
+        $data = [
+            'id' => $entityId,
+            'values' => $entityValues,
+            'doc' => $description,
+            'lookups' => $lookups,
+        ];
+
+        $response = $this->client->post('/entities', $data);
+
+        return $this->decodeResponse($response);
+    }
+}

--- a/src/MessageApi.php
+++ b/src/MessageApi.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tgallice\Wit;
+
+use Tgallice\Wit\Model\Context;
+
+class MessageApi
+{
+    use ResponseHandler;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param string $text
+     * @param Context|null $context
+     * @param array $extraParams
+     *
+     * @return mixed
+     */
+    public function extractMeaning($text, Context $context = null, array $extraParams = [])
+    {
+        $query = array_merge($extraParams, [
+            'q' => $text,
+        ]);
+
+        if (null !== $context) {
+            $query['context'] = json_encode($context);
+        }
+
+        $response = $this->client->get('/message', $query);
+
+        return $this->decodeResponse($response);
+    }
+}

--- a/src/Model/Entity.php
+++ b/src/Model/Entity.php
@@ -4,6 +4,10 @@ namespace Tgallice\Wit\Model;
 
 class Entity implements \JsonSerializable
 {
+    const LOOKUP_TRAIT = 'trait';
+
+    const LOOKUP_KEYWORDS = 'keywords';
+
     /**
      * @var string
      */
@@ -20,15 +24,22 @@ class Entity implements \JsonSerializable
     private $description;
 
     /**
-     * @param $id
-     * @param array $values
-     * @param string|null $description
+     * @var string[]
      */
-    public function __construct($id, array $values = [], $description = '')
+    private $lookups;
+
+    /**
+     * @param $id
+     * @param array|EntityValue[] $values
+     * @param string|null $description
+     * @param string[] $lookups
+     */
+    public function __construct($id, array $values = [], $description = '', array $lookups = [Entity::LOOKUP_KEYWORDS])
     {
         $this->id = $id;
         $this->values = $values;
         $this->description = $description;
+        $this->lookups = $lookups;
     }
 
     /**
@@ -48,11 +59,19 @@ class Entity implements \JsonSerializable
     }
 
     /**
-     * @return array
+     * @return array|EntityValue[]
      */
     public function getValues()
     {
         return $this->values;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLookups()
+    {
+        return $this->lookups;
     }
 
     /**
@@ -64,6 +83,7 @@ class Entity implements \JsonSerializable
             'id' => $this->id,
             'values' => $this->values,
             'doc' => $this->description,
+            'lookups' => $this->lookups,
         ];
     }
 }

--- a/src/Model/EntityValue.php
+++ b/src/Model/EntityValue.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tgallice\Wit\Model;
+
+class EntityValue implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @var string[]
+     */
+    private $expressions;
+
+    /**
+     * @var null|string
+     */
+    private $metadata;
+
+    /**
+     * @param $value
+     * @param string[] $expressions
+     * @param null|string $metadata
+     */
+    public function __construct($value, array $expressions = [], $metadata = null)
+    {
+        $this->value = $value;
+        $this->expressions = $expressions;
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExpressions()
+    {
+        return $this->expressions;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize()
+    {
+        $data = [
+            'value' => $this->value,
+        ];
+
+        if (!empty($this->expressions)) {
+            $data['expressions'] = $this->expressions;
+        }
+
+        if (!empty($this->metadata)) {
+            $data['metadata'] = $this->metadata;
+        }
+
+        return $data;
+    }
+}

--- a/src/SpeechApi.php
+++ b/src/SpeechApi.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tgallice\Wit;
+
+use Tgallice\Wit\Model\Context;
+
+class SpeechApi
+{
+    use ResponseHandler;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param string|resource $file
+     * @param array|null $context
+     * @param array $queryParams
+     *
+     * @return array|null
+     */
+    public function extractMeaning($file, Context $context = null, array $queryParams = [])
+    {
+        if (!$file || (!is_resource($file) && !is_readable($file))) {
+            throw new \InvalidArgumentException('$file argument must be a readable file path or a valid resource');
+        }
+
+        if (null !== $context) {
+            $queryParams['context'] = json_encode($context);
+        }
+
+        $file = is_resource($file) ? $file : fopen($file, 'r');
+        $response = $this->client->send('POST', '/speech', $file, $queryParams);
+
+        return $this->decodeResponse($response);
+    }
+}


### PR DESCRIPTION
- Deprecate `Api` class. Use appropriate Api class (MessageApi etc..)
- Deprecate `Api\Conversation` class. Use `\Conversation` instead
- `EntityApi` added
- Bumped the api version to `20160526`

closes #4 