### PR TITLE
Support entities for all steps

### DIFF
--- a/spec/ConversationSpec.php
+++ b/spec/ConversationSpec.php
@@ -59,7 +59,12 @@ class ConversationSpec extends ObjectBehavior
 
         // Second step
         $api->converse('session_id', null, $expectedContext)->willReturn($this->stepData[Step::TYPE_MESSAGE]);
-        $actionMapping->say('session_id', $this->stepData[Step::TYPE_MESSAGE]['msg'], $expectedContext)->shouldBeCalled();
+        $actionMapping->say(
+            'session_id',
+            $this->stepData[Step::TYPE_MESSAGE]['msg'],
+            $expectedContext,
+            Argument::type('array')
+        )->shouldBeCalled();
 
         $this->converse('session_id', 'my text', $context)->shouldReturn($expectedContext);
     }
@@ -141,7 +146,7 @@ class ConversationSpec extends ObjectBehavior
         $expectedContext->add('custom', 'value');
 
         $actionMapping
-            ->action('session_id', $this->stepData[Step::TYPE_ACTION]['action'], Argument::type(Context::class))
+            ->action('session_id', $this->stepData[Step::TYPE_ACTION]['action'], Argument::type(Context::class), Argument::type('array'))
             ->willReturn($expectedContext);
 
         $api->converse('session_id', null, $expectedContext)->willReturn($this->stepData[Step::TYPE_STOP]);
@@ -168,7 +173,7 @@ class ConversationSpec extends ObjectBehavior
     {
         $api->converse('session_id', 'my text', Argument::any())->willReturn($this->stepData[Step::TYPE_MESSAGE]);
         $actionMapping
-            ->say('session_id', 'message', Argument::type(Context::class))
+            ->say('session_id', 'message', Argument::type(Context::class), Argument::type('array'))
             ->shouldBeCalled();
 
         $context = new Context();

--- a/src/ActionMapping.php
+++ b/src/ActionMapping.php
@@ -11,17 +11,19 @@ abstract class ActionMapping
      * @param string $sessionId
      * @param string $actionName
      * @param Context $context
-     *
+     * @param array $entities
+     * 
      * @return Context
      */
-    abstract public function action($sessionId, $actionName, Context $context);
+    abstract public function action($sessionId, $actionName, Context $context, array $entities = []);
 
     /**
      * @param string $sessionId
-     * @param Context $context
      * @param string $message
+     * @param Context $context
+     * @param array $entities
      */
-    abstract public function say($sessionId, $message, Context $context);
+    abstract public function say($sessionId, $message, Context $context, array $entities = []);
 
     /**
      * @param string $sessionId
@@ -38,7 +40,7 @@ abstract class ActionMapping
      *
      * @return Context
      */
-    abstract public function merge($sessionId, Context $context, array $entities);
+    abstract public function merge($sessionId, Context $context, array $entities = []);
 
     /**
      * @param string $sessionId

--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -112,10 +112,10 @@ class Conversation
                 $context = $this->converse($sessionId, null, $newContext, --$currentIteration);
                 break;
             case $step instanceof Message:
-                $this->actionMapping->say($sessionId, $step->getMessage(), $context);
+                $this->actionMapping->say($sessionId, $step->getMessage(), $context, $step->getEntities());
                 break;
             case $step instanceof Action:
-                $newContext = $this->actionMapping->action($sessionId, $step->getAction(), $context);
+                $newContext = $this->actionMapping->action($sessionId, $step->getAction(), $context, $step->getEntities());
                 $context = $this->converse($sessionId, null, $newContext, --$currentIteration);
                 break;
             case $step instanceof Stop:

--- a/src/Model/Step.php
+++ b/src/Model/Step.php
@@ -19,4 +19,9 @@ interface Step
      * @return float
      */
     public function getConfidence();
+
+    /**
+     * @return array
+     */
+    public function getEntities();
 }

--- a/src/Model/Step/AbstractStep.php
+++ b/src/Model/Step/AbstractStep.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Hannes Finck <finck.hannes@gmail.com>
+ */
+
+namespace Tgallice\Wit\Model\Step;
+
+
+use Tgallice\Wit\Model\Step;
+
+abstract class AbstractStep implements Step
+{
+    /**
+     * @var float
+     */
+    private $confidence;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var array
+     */
+    private $entities;
+
+    /**
+     * AbstractStep constructor.
+     * @param string $type
+     * @param float $confidence
+     * @param array $entities
+     */
+    public function __construct($type, $confidence, array $entities = [])
+    {
+        $this->type = $type;
+        $this->confidence = (float) $confidence;
+        $this->entities = $entities;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return float
+     */
+    public function getConfidence()
+    {
+        return $this->confidence;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntities()
+    {
+        return $this->entities;
+    }
+}

--- a/src/Model/Step/Action.php
+++ b/src/Model/Step/Action.php
@@ -4,7 +4,7 @@ namespace Tgallice\Wit\Model\Step;
 
 use Tgallice\Wit\Model\Step;
 
-class Action implements Step
+class Action extends AbstractStep
 {
     /**
      * @var string
@@ -12,18 +12,14 @@ class Action implements Step
     private $action;
 
     /**
-     * @var float
-     */
-    private $confidence;
-
-    /**
      * @param string $action
      * @param float $confidence
+     * @param array $entities
      */
-    public function __construct($action, $confidence)
+    public function __construct($action, $confidence, array $entities = [])
     {
+        parent::__construct(Step::TYPE_ACTION, $confidence, $entities);
         $this->action = $action;
-        $this->confidence = (float) $confidence;
     }
 
     /**
@@ -32,21 +28,5 @@ class Action implements Step
     public function getAction()
     {
         return $this->action;
-    }
-
-    /**
-     * @return float
-     */
-    public function getConfidence()
-    {
-        return $this->confidence;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return Step::TYPE_ACTION;
     }
 }

--- a/src/Model/Step/Merge.php
+++ b/src/Model/Step/Merge.php
@@ -4,49 +4,14 @@ namespace Tgallice\Wit\Model\Step;
 
 use Tgallice\Wit\Model\Step;
 
-class Merge implements Step
+class Merge extends AbstractStep
 {
-    /**
-     * @var float
-     */
-    private $confidence;
-
-    /**
-     * @var array
-     */
-    private $entities;
-
     /**
      * @param array $entities
      * @param float $confidence
      */
     public function __construct(array $entities, $confidence)
     {
-        $this->confidence = (float) $confidence;
-        $this->entities = $entities;
-    }
-
-    /**
-     * @return array
-     */
-    public function getEntities()
-    {
-        return $this->entities;
-    }
-
-    /**
-     * @return float
-     */
-    public function getConfidence()
-    {
-        return $this->confidence;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return Step::TYPE_MERGE;
+        parent::__construct(Step::TYPE_MERGE, $confidence, $entities);
     }
 }

--- a/src/Model/Step/Message.php
+++ b/src/Model/Step/Message.php
@@ -4,13 +4,8 @@ namespace Tgallice\Wit\Model\Step;
 
 use Tgallice\Wit\Model\Step;
 
-class Message implements Step
+class Message extends AbstractStep
 {
-    /**
-     * @var float
-     */
-    private $confidence;
-
     /**
      * @var string
      */
@@ -19,10 +14,11 @@ class Message implements Step
     /**
      * @param string $message
      * @param float $confidence
+     * @param array $entities
      */
-    public function __construct($message, $confidence)
+    public function __construct($message, $confidence, array $entities = [])
     {
-        $this->confidence = (float) $confidence;
+        parent::__construct(Step::TYPE_MESSAGE, $confidence, $entities);
         $this->message = $message;
     }
 
@@ -32,21 +28,5 @@ class Message implements Step
     public function getMessage()
     {
         return $this->message;
-    }
-
-    /**
-     * @return float
-     */
-    public function getConfidence()
-    {
-        return $this->confidence;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return Step::TYPE_MESSAGE;
     }
 }

--- a/src/Model/Step/Stop.php
+++ b/src/Model/Step/Stop.php
@@ -4,34 +4,13 @@ namespace Tgallice\Wit\Model\Step;
 
 use Tgallice\Wit\Model\Step;
 
-class Stop implements Step
+class Stop extends AbstractStep
 {
-    /**
-     * @var float
-     */
-    private $confidence;
-
     /**
      * @param float $confidence
      */
     public function __construct($confidence)
     {
-        $this->confidence = (float) $confidence;
-    }
-
-    /**
-     * @return float
-     */
-    public function getConfidence()
-    {
-        return $this->confidence;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return Step::TYPE_STOP;
+        parent::__construct(Step::TYPE_STOP, $confidence);
     }
 }

--- a/src/StepFactory.php
+++ b/src/StepFactory.php
@@ -32,11 +32,21 @@ class StepFactory
     /**
      * @param array $step
      *
+     * @return array
+     */
+    private static function getEntitiesFromStepData(array $step = [])
+    {
+        return isset($step['entities']) ? $step['entities'] : [];
+    }
+
+    /**
+     * @param array $step
+     *
      * @return Action
      */
     public static function createActionStep(array $step)
     {
-        return new Action($step['action'], $step['confidence']);
+        return new Action($step['action'], $step['confidence'], self::getEntitiesFromStepData($step));
     }
 
     /**
@@ -46,7 +56,7 @@ class StepFactory
      */
     public static function createMergeStep(array $step)
     {
-        return new Merge($step['entities'], $step['confidence']);
+        return new Merge(self::getEntitiesFromStepData($step), $step['confidence']);
     }
 
     /**
@@ -56,7 +66,7 @@ class StepFactory
      */
     public static function createMessageStep(array $step)
     {
-        return new Message($step['msg'], $step['confidence']);
+        return new Message($step['msg'], $step['confidence'], self::getEntitiesFromStepData($step));
     }
 
     /**


### PR DESCRIPTION
#### Why I changed it
Since the release of wit.ai bot engine v1.0 [(see here)](https://wit.ai/blog/2016/06/28/bot-engine-v1) the merge step has been made optional, meaning that also other steps such as "say" and "action" potentially receive extracted entities.

#### What has changed
I refactored the step model entities and extracted the similarities into an AbstractStep, which now holds the type, confidence and entities attributes. The actual steps only need to add their specific attributes.

The ActionMapping has been modified to accept an entity array for the say and action functions. The StepFactory now constructs steps with extracted entities in case there are any.
I also updated the tests to reflect these changes.

I really like the solid base you provided here. Thank you! :-)