### PR TITLE
Execute converse after a say action

### DIFF
--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -113,6 +113,7 @@ class Conversation
                 break;
             case $step instanceof Message:
                 $this->actionMapping->say($sessionId, $step->getMessage(), $context, $step->getEntities());
+                $context = $this->converse($sessionId, null, $context, --$currentIteration);
                 break;
             case $step instanceof Action:
                 $newContext = $this->actionMapping->action($sessionId, $step->getAction(), $context, $step->getEntities());


### PR DESCRIPTION
Currently there is the problem that within `ActionMapping::performStep` converse is not called again after a say action, which leads to unexpected results in the following steps.
We have to converse until we receive the final `stop` message from wit.ai.

I fixed it and updated the test specs according to changed performStep behavior.