### PR TITLE
Ignore Jetbrains IDE settings folder and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/
 /vendor/
+/.idea
 composer.lock
 


### PR DESCRIPTION
I think many people probably use a version of the Jetbrains IDE for PHP so I took the liberty of adding it's control folder to the .gitignore file.