### PR TITLE
Setters for reference_time and timezone in Context.

### DIFF
--- a/spec/Model/ContextSpec.php
+++ b/spec/Model/ContextSpec.php
@@ -3,7 +3,6 @@
 namespace spec\Tgallice\Wit\Model;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Tgallice\Wit\Model\Entity;
 use Tgallice\Wit\Model\Location;
 
@@ -21,13 +20,9 @@ class ContextSpec extends ObjectBehavior
 
     function it_can_define_a_reference_time()
     {
-        $date = new \DateTime();
-        $asString = $date->format(DATE_ISO8601);
-
-        $this->beConstructedWith([
-            'reference_time' => $asString,
-        ]);
-        $this->getReferenceTime()->shouldReturn($asString);
+        $dt = new \DateTimeImmutable();
+        $this->setReferenceTime($dt);
+        $this->getReferenceTime()->shouldReturn($dt->format(DATE_ISO8601));
     }
 
     function it_has_no_default_location()
@@ -74,12 +69,11 @@ class ContextSpec extends ObjectBehavior
         $this->getTimezone()->shouldReturn(null);
     }
 
-    function it_can_define_timezone()
+    function it_can_define_a_timezone()
     {
-        $this->beConstructedWith([
-            'timezone' => 'europe/paris',
-        ]);
-        $this->getTimezone()->shouldReturn('europe/paris');
+        $timezone = 'Europe/Paris';
+        $this->setTimezone($timezone);
+        $this->getTimezone()->shouldReturn($timezone);
     }
 
     function it_can_add_custom_context_field()
@@ -113,6 +107,7 @@ class ContextSpec extends ObjectBehavior
     function it_must_be_json_serializable()
     {
         $this->shouldHaveType(\JsonSerializable::class);
+        $this->add('custom', 'value');
         $serialized = json_encode($this->getWrappedObject());
         $this->jsonSerialize()->shouldReturn(json_decode($serialized, true));
     }

--- a/src/Model/Context.php
+++ b/src/Model/Context.php
@@ -14,7 +14,6 @@ class Context implements \JsonSerializable
      */
     public function __construct($data = [])
     {
-
         $this->data = $data;
     }
 
@@ -35,13 +34,24 @@ class Context implements \JsonSerializable
     }
 
     /**
-     * Return the reference date in the ISO8601 format
+     * Return the reference date in ISO8601 format
      *
      * @return string|null
      */
     public function getReferenceTime()
     {
         return $this->getContextField('reference_time');
+    }
+
+    /**
+     * Set the reference time in ISO8601 format
+     *
+     * @param \DateTimeInterface $dateTime
+     */
+    public function setReferenceTime(\DateTimeInterface $dateTime)
+    {
+        $dt = $dateTime->format(DATE_ISO8601);
+        $this->add('reference_time', $dt);
     }
 
     /**
@@ -58,6 +68,15 @@ class Context implements \JsonSerializable
     public function getTimezone()
     {
         return $this->getContextField('timezone');
+    }
+
+    /**
+     * @param string $timezone Timezone identifier e.g 'Europe/Berlin'
+     */
+    public function setTimezone($timezone)
+    {
+        $tz = new \DateTimeZone($timezone);
+        $this->add('timezone', $tz->getName());
     }
 
     /**


### PR DESCRIPTION
People should be able to set the reference_time and timezone to their liking so I added the appropriate setters for that.

As we only accept a date time interface we can make sure that it is properly formatted as required by wit.ai.
```php
public function setReferenceTime(\DateTimeInterface $dateTime)
{
    $dt = $dateTime->format(DATE_ISO8601);
    $this->add('reference_time', $dt);
}
```

Same thing for the time zone. It will error out if a non-valid timezone string is applied.

We also make sure that an empty context is serialised to an empty JSON object. Otherwise we would get an empty array, which will be rejected by wit.ai with an error.
```php
    public function jsonSerialize()
    {
        return $this->data ?: new \stdClass;
    }
```